### PR TITLE
Added default monitor validation tests. Allow swarm default monitors.

### DIFF
--- a/monitors_test.go
+++ b/monitors_test.go
@@ -1,0 +1,135 @@
+package libyaml_test
+
+import (
+	"testing"
+
+	. "github.com/replicatedhq/libyaml"
+	validator "gopkg.in/go-playground/validator.v8"
+)
+
+func TestMonitorsDefault(t *testing.T) {
+	v := validator.New(&validator.Config{TagName: "validate"})
+	err := RegisterValidations(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runs := []ValidateTestRun{
+		{
+			`---
+replicated_api_version: "2.8.0"
+components:
+  - name: wrong
+    containers:
+      - image_name: quay.io/getelk/logstash
+        source: public
+        version: "1.0.0"
+monitors:
+  cpuacct:
+    - Logstash,quay.io/getelk/logstash
+`,
+			map[string]string{
+				"RootConfig.Monitors.Cpuacct[0]": "componentexists",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+components:
+  - name: Logstash
+    containers:
+      - image_name: quay.io/something/else
+        source: public
+        version: "1.0.0"
+monitors:
+  cpuacct:
+    - Logstash,quay.io/getelk/logstash
+`,
+			map[string]string{
+				"RootConfig.Monitors.Cpuacct[0]": "containerexists",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+monitors:
+  cpuacct:
+    - incomplete
+`,
+			map[string]string{
+				"RootConfig.Monitors.Cpuacct[0]": "componentcontainer",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+monitors:
+  cpuacct:
+    - somethingswarm
+swarm:
+  minimum_node_count: "1"
+`,
+			map[string]string{
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+components:
+  - name: wrong
+    containers:
+      - image_name: quay.io/getelk/logstash
+        source: public
+        version: "1.0.0"
+monitors:
+  memory:
+    - Logstash,quay.io/getelk/logstash
+`,
+			map[string]string{
+				"RootConfig.Monitors.Memory[0]": "componentexists",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+components:
+  - name: Logstash
+    containers:
+      - image_name: quay.io/something/else
+        source: public
+        version: "1.0.0"
+monitors:
+  memory:
+    - Logstash,quay.io/getelk/logstash
+`,
+			map[string]string{
+				"RootConfig.Monitors.Memory[0]": "containerexists",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+monitors:
+  memory:
+    - incomplete
+`,
+			map[string]string{
+				"RootConfig.Monitors.Memory[0]": "componentcontainer",
+			},
+		},
+		{
+			`---
+replicated_api_version: "2.8.0"
+monitors:
+  memory:
+    - somethingswarm
+swarm:
+  minimum_node_count: "1"
+`,
+			map[string]string{
+			},
+		},
+	}
+
+	RunValidateTest(t, runs, v, RootConfig{})
+}

--- a/validate.go
+++ b/validate.go
@@ -519,6 +519,14 @@ func ComponentExistsValidation(v *validator.Validate, topStruct reflect.Value, c
 
 	parts := strings.SplitN(componentName, ",", 2)
 
+	if len(parts) == 1 {
+		//This might be a swarm config
+		//If the scheduler is swarm, accept it
+		if IsSwarm(root) {
+			return true
+		}
+	}
+
 	if len(parts) >= 2 {
 		componentName = parts[0]
 	}
@@ -637,6 +645,17 @@ func ComponentContainerFormatValidation(v *validator.Validate, topStruct reflect
 	}
 
 	parts := strings.SplitN(field.String(), ",", 2)
+
+	if len(parts) == 1 {
+		//This might be a swarm config
+		//If the scheduler is swarm, accept it
+		root, ok := topStruct.Interface().(*RootConfig)
+		if !ok {
+			// this is an issue with the code and really should be a panic
+			return true
+		}
+		return IsSwarm(root)
+	}
 
 	if len(parts) < 2 {
 		return false
@@ -1226,4 +1245,8 @@ func dependsOn(subscriptions map[string]string, current string, subscribed strin
 		}
 	}
 	return dependsOn(nextSubscriptions, nextCurrent, subscribed)
+}
+
+func IsSwarm(root *RootConfig) bool {
+	return root.Swarm != nil
 }


### PR DESCRIPTION
Allow default monitors on the swarm scheduler by allowing service names to be used within monitors.memory, but only if swarm is present

Service names are not validated beyond 'string that has no commas' - you can request a monitor for a service that does not exist.